### PR TITLE
add table's cell colspan binding

### DIFF
--- a/addon/components/paper-data-table-cell.js
+++ b/addon/components/paper-data-table-cell.js
@@ -7,7 +7,7 @@ export default Ember.Component.extend({
 	layout,
 	tagName: 'td',
 	classNameBindings: ['numeric:md-numeric','edit:md-clickable'],
-	attributeBindings: ['style'],
+	attributeBindings: ['style','colspan'],
 	classNames: ['md-cell'],
 	edit: false,
 	showEdit: false,


### PR DESCRIPTION
Add a way to set the colspan's attribute on the cell object.

It can be useful to handle the empty state of the table with a single body cell that display a message to the user.

Thanks for sharing this component it saved me quick some times 👍 