### PR TITLE
add opt-in for start/end offset of the current page

### DIFF
--- a/addon/components/paper-data-table-pagination.js
+++ b/addon/components/paper-data-table-pagination.js
@@ -4,5 +4,11 @@ import layout from '../templates/components/paper-data-table-pagination';
 export default Ember.Component.extend({
 	layout,
 	tagName: 'md-table-pagination',
-	classNames: ['md-table-pagination']
+	classNames: ['md-table-pagination'],
+	startOffset: Ember.computed('page', 'limit', function() {
+		return Math.max((this.get('page') - 1) * this.get('limit') + 1, 1); // 1-based index
+	}),
+	endOffset: Ember.computed('startOffset', 'limit', function() {
+		return this.get('startOffset') + this.get('limit');
+	})
 });

--- a/addon/templates/components/paper-data-table-pagination.hbs
+++ b/addon/templates/components/paper-data-table-pagination.hbs
@@ -11,6 +11,7 @@
 	{{/paper-table-select}}
 </div>
 <div class="buttons">
+	{{#if total}}<div class="label">{{startOffset}} - {{endOffset}} of {{total}}</div>{{/if}}
 	{{#paper-button iconButton=true onClick=onDecrementPage}}{{paper-icon "navigate before"}}{{/paper-button}}
 	{{#paper-button iconButton=true onClick=onIncrementPage}}{{paper-icon "navigate next"}}{{/paper-button}}
 </div>

--- a/tests/unit/components/paper-data-table-pagination-test.js
+++ b/tests/unit/components/paper-data-table-pagination-test.js
@@ -1,0 +1,46 @@
+import { moduleForComponent, test } from 'ember-qunit';
+
+moduleForComponent('paper-data-table-pagination', 'Unit | Component | paper data table pagination', {
+  unit: true
+});
+
+test('startOffset starts at 1', function(assert) {
+  assert.equal(this.subject({ page: 1, limit: 10 }).get('startOffset'), 1);
+});
+
+test('startOffset cannot be negative', function(assert) {
+  assert.equal(this.subject({ page: -1, limit: 10 }).get('startOffset'), 1);
+});
+
+test('startOffset is updated with page and limit', function(assert) {
+  const subject = this.subject({ page: 10, limit: 100 });
+
+  assert.equal(subject.get('startOffset'), 901);
+
+  subject.set('page', 2);
+
+  assert.equal(subject.get('startOffset'), 101);
+
+  subject.set('limit', 1);
+
+  assert.equal(subject.get('startOffset'), 2);
+});
+
+test('endOffset is the sum of startOffset and limit', function(assert) {
+  assert.equal(this.subject({ page: 1, limit: 10 }).get('endOffset'), 11);
+});
+
+test('endOffset is updated with page and limit', function(assert) {
+  const subject = this.subject({ page: 10, limit: 100 });
+
+  assert.equal(subject.get('endOffset'), 1001);
+
+  subject.set('page', 2);
+
+  assert.equal(subject.get('endOffset'), 201);
+
+  subject.set('limit', 1);
+
+  assert.equal(subject.get('endOffset'), 3);
+});
+


### PR DESCRIPTION
By default, nothing change.

If the user specify the `total` attribute then we display the start/end offsets with the total number of item.