### PR TITLE
can opt-out page selection by omitting the change action

### DIFF
--- a/addon/templates/components/paper-data-table-pagination.hbs
+++ b/addon/templates/components/paper-data-table-pagination.hbs
@@ -1,9 +1,11 @@
+{{#if onChangePage}}
 <div class="page-select">
 	<div class="md-table-label">Page:</div>
 	{{#paper-table-select options=pages selected=page onChange=onChangePage as |pageNumber|}}
 		{{pageNumber}}
 	{{/paper-table-select}}
 </div>
+{{/if}}
 <div class="limit-select">
 	<div class="md-table-label">Rows per page:</div>
 	{{#paper-table-select options=limitOptions selected=limit onChange=onChangeLimit as |limit|}}


### PR DESCRIPTION
If the `onChangePage` action is not specified then we do not display the page selection.

For example, in my case I can have thousands of page which make the select unusable and buggy.
