### PR TITLE
Upgrade to ember 2.10 & fix backtrace/backflow errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
 /dist
@@ -13,5 +13,5 @@
 /connect.lock
 /coverage/*
 /libpeerconnection.log
-npm-debug.log
+npm-debug.log*
 testem.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,13 @@ sudo: false
 
 cache:
   directories:
-    - node_modules
+    - $HOME/.npm
+    - $HOME/.cache # includes bowers cache
 
 env:
-  - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-1.13
+  # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
+  - EMBER_TRY_SCENARIO=ember-lts-2.4
+  - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
@@ -24,7 +26,9 @@ matrix:
 before_install:
   - npm config set spin false
   - npm install -g bower
+  - bower --version
   - npm install phantomjs-prebuilt
+  - node_modules/phantomjs-prebuilt/bin/phantomjs --version
 
 install:
   - npm install
@@ -33,4 +37,4 @@ install:
 script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
-  - ember try $EMBER_TRY_SCENARIO test --skip-cleanup
+  - ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup

--- a/README.md
+++ b/README.md
@@ -9,48 +9,63 @@ Port of https://github.com/daniel-nagy/md-data-table using ember-paper
 ## Usage
 	From dummy app:
   ```hbs
-{{#paper-data-table selectable=true as |table|}}
-	{{#table.head as |head|}}
-		{{#head.column checkbox=true}}
-			{{#paper-checkbox disabled=true onChange=null}}{{/paper-checkbox}}
-		{{/head.column}}
-		{{#head.column sortProp="name"}}Dessert (100g serving){{/head.column}}
-		{{#head.column sortProp="calories" numeric=true}}Calories{{/head.column}}
-		{{#head.column sortProp="fat" numeric=true}}Fat (g){{/head.column}}
-		{{#head.column sortProp="carbs" numeric=true}}Carbs (g){{/head.column}}
-		{{#head.column sortProp="protein" numeric=true}}Protein (g){{/head.column}}
-		{{#head.column numeric=true}}Sodium (mg){{/head.column}}
-		{{#head.column numeric=true}}Calcium (%){{/head.column}}
-		{{#head.column numeric=true}}Iron (%){{/head.column}}
-		{{#head.column}}Comment{{/head.column}}
-	{{/table.head}}
-	{{#table.body as |body|}}
-		{{#each (sort-by table.sortProp paginatedDesserts) as |dessert|}}
-			{{#body.row edit=true as |row|}}
-				{{#row.cell checkbox=true}}
-					{{#paper-checkbox value=dessert.checked onChange=(action (mut dessert.checked))}}{{/paper-checkbox}}
-				{{/row.cell}}
-				{{#row.cell}}{{dessert.name}}{{/row.cell}}
-				{{#row.cell numeric=true}}{{dessert.calories}}{{/row.cell}}
-				{{#row.cell numeric=true}}{{dessert.fat}}{{/row.cell}}
-				{{#row.cell numeric=true}}{{dessert.carbs}}{{/row.cell}}
-				{{#row.cell numeric=true}}{{dessert.protein}}{{/row.cell}}
-				{{#row.cell numeric=true}}{{dessert.sodium}}{{/row.cell}}
-				{{#row.cell numeric=true}}{{dessert.calcium}}%{{/row.cell}}
-				{{#row.cell numeric=true}}{{dessert.iron}}%{{/row.cell}}
-				{{#row.cell edit=true as |cell|}}
-					{{#if cell.showEdit}}
-						{{#cell.edit-dialog onClose=cell.toggleEdit}}
-							{{paper-input value=dessert.comment onChange=(action (mut dessert.comment))}}
-						{{/cell.edit-dialog}}
-					{{else}}
-						{{dessert.comment}}{{#paper-button iconButton=true onClick=row.toggleEdit}}{{paper-icon 'edit'}}{{/paper-button}}
-					{{/if}}
-				{{/row.cell}}
-			{{/body.row}}
-		{{/each}}
-	{{/table.body}}
+{{#paper-data-table sortProp="name" sortDir="desc" selectable=true as |table|}}
+  {{#table.head as |head|}}
+    {{#head.column checkbox=true}}
+      {{#paper-checkbox disabled=true onChange=null}}{{/paper-checkbox}}
+    {{/head.column}}
+    {{#head.column sortProp="name"}}Dessert (100g serving){{/head.column}}
+    {{#head.column sortProp="calories" numeric=true}}Calories{{/head.column}}
+    {{#head.column sortProp="fat" numeric=true}}Fat (g){{/head.column}}
+    {{#head.column sortProp="carbs" numeric=true}}Carbs (g){{/head.column}}
+    {{#head.column sortProp="protein" numeric=true}}Protein (g){{/head.column}}
+    {{#head.column numeric=true}}Sodium (mg){{/head.column}}
+    {{#head.column numeric=true}}Calcium (%){{/head.column}}
+    {{#head.column numeric=true}}Iron (%){{/head.column}}
+    {{#head.column}}Comment{{/head.column}}
+  {{/table.head}}
+  {{#table.body as |body|}}
+    {{#each (sort-by table.sortDesc paginatedDesserts) as |dessert|}}
+      {{#body.row edit=true as |row|}}
+        {{#row.cell checkbox=true}}
+          {{#paper-checkbox
+            value=dessert.checked
+            onChange=(action (mut dessert.checked))}}
+          {{/paper-checkbox}}
+        {{/row.cell}}
+        {{#row.cell}}{{dessert.name}}{{/row.cell}}
+        {{#row.cell numeric=true}}{{dessert.calories}}{{/row.cell}}
+        {{#row.cell numeric=true}}{{dessert.fat}}{{/row.cell}}
+        {{#row.cell numeric=true}}{{dessert.carbs}}{{/row.cell}}
+        {{#row.cell numeric=true}}{{dessert.protein}}{{/row.cell}}
+        {{#row.cell numeric=true}}{{dessert.sodium}}{{/row.cell}}
+        {{#row.cell numeric=true}}{{dessert.calcium}}%{{/row.cell}}
+        {{#row.cell numeric=true}}{{dessert.iron}}%{{/row.cell}}
+        {{#row.cell edit=true as |cell|}}
+          {{#if cell.showEdit}}
+            {{#cell.edit-dialog onClose=cell.toggleEdit}}
+              {{paper-input
+                value=dessert.comment
+                onChange=(action (mut dessert.comment))}}
+            {{/cell.edit-dialog}}
+          {{else}}
+            {{dessert.comment}}
+            {{#paper-button iconButton=true onClick=row.toggleEdit}}
+              {{paper-icon 'edit'}}
+            {{/paper-button}}
+          {{/if}}
+        {{/row.cell}}
+      {{/body.row}}
+    {{/each}}
+  {{/table.body}}
 {{/paper-data-table}}
-{{paper-data-table-pagination limit=limit limitOptions=limitOptions page=page pages=pages onChangePage=(action (mut page)) onChangeLimit=(action (mut limit)) onIncrementPage=(action 'incrementPage') onDecrementPage=(action 'decrementPage')}}
-
+{{paper-data-table-pagination
+  limit=limit
+  limitOptions=limitOptions
+  page=page
+  pages=pages
+  onChangePage=(action (mut page))
+  onChangeLimit=(action (mut limit))
+  onIncrementPage=(action 'incrementPage')
+  onDecrementPage=(action 'decrementPage')}}
 ```

--- a/addon/components/paper-data-table-body.js
+++ b/addon/components/paper-data-table-body.js
@@ -3,7 +3,7 @@ import layout from '../templates/components/paper-data-table-body';
 
 export default Ember.Component.extend({
 	layout,
-  	tagName: '',
+  tagName: '',
 	cellspacing: "0",
-	cellpadding: "0"
+	cellpadding: "0",
 });

--- a/addon/components/paper-data-table-head.js
+++ b/addon/components/paper-data-table-head.js
@@ -1,31 +1,10 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-data-table-head';
 
-let {
-	K: noop
-} = Ember;
 
 export default Ember.Component.extend({
 	layout,
 	tagName: '',
 	cellpadding: "0",
 	cellspacing: "0",
-	sortProp: null,
-	sortDir: null,
-
-	didReceiveAttrs() {
-		this._super(...arguments);
-		let { sortProp, sortDir } = this.getProperties('sortProp', 'sortDir');
-
-		if (sortProp && sortDir) {
-			this.send('sortChanged', sortProp, sortDir);
-		}
-	},
-	actions: {
-		sortChanged(prop, dir) {
-			let action = this.get('setSortProp') || noop;
-			action(`${prop}:${dir}`);
-			this.set('sortProp', prop);
-		}
-	}
 });

--- a/addon/components/paper-data-table.js
+++ b/addon/components/paper-data-table.js
@@ -1,16 +1,31 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-data-table';
 
-export default Ember.Component.extend({
+const {
+	Component,
+	computed
+} = Ember;
+
+export default Component.extend({
 	layout,
 	tagName: 'md-table-container',
 	classNameBindings: ['noPadding:no-padding-table'],
-	rowWidth: 0,
-	sortProp: "",
-	selectable: false,
-
 	bodyComponent: 'paper-data-table-body',
 	bodyRowComponent: 'paper-data-table-row',
-	headComponent: 'paper-data-table-head'
+	headComponent: 'paper-data-table-head',
+	rowWidth: 0,
+	sortProp: "name",
+	sortDir: "asc",
+	selectable: false,
 
+	sortDesc: computed('sortProp', 'sortDir', function() {
+		let sortDesc = this.getProperties('sortProp', 'sortDir');
+		return `${sortDesc.sortProp}:${sortDesc.sortDir}`;
+	}).readOnly(),
+
+	actions: {
+		sortChanged(sortProp, sortDir) {
+			this.setProperties({ sortProp, sortDir });
+		}
+	}
 });

--- a/addon/templates/components/paper-data-table-head.hbs
+++ b/addon/templates/components/paper-data-table-head.hbs
@@ -5,18 +5,23 @@
 		{{/unless}}
 		{{yield (hash
 			column=(component 'paper-data-table-column'
-				sortChanged=(action 'sortChanged')
+				sortChanged=onSortChanged
 				currentProp=(readonly sortProp)
-				sortDir=(readonly sortDir))
-			)}}
+				sortDir=(readonly sortDir)
+			)
+		)}}
 	</tr>
 </thead>
 {{#if headersWormhole}}
 	{{#ember-wormhole destinationElement=headersWormhole}}
 	<tr id="hidden-row" style="visibility: hidden;">
 		{{yield (hash
-			column=(component 'paper-data-table-column' sortChanged=(action 'sortChanged')
-			currentProp=currentProp))}}
+			column=(component 'paper-data-table-column'
+				sortChanged=onSortChanged
+				currentProp=(readonly sortProp)
+				sortDir=(readonly sortDir)
+			)
+		)}}
 	</tr>
 	{{/ember-wormhole}}
 {{/if}}

--- a/addon/templates/components/paper-data-table.hbs
+++ b/addon/templates/components/paper-data-table.hbs
@@ -1,14 +1,18 @@
 <table class="md-table md-row-select" style={{if fixed "table-layout: fixed;"}}>
 	{{yield (hash
+		sortProp=(readonly sortProp)
+		sortDir=(readonly sortDir)
+		sortDesc=(readonly sortDesc)
 		head=(component headComponent
 			selectable=selectable
-			setSortProp=(action (mut sortProp))
+			sortProp=(readonly sortProp)
+			sortDir=(readonly sortDir)
+			onSortChanged=(action 'sortChanged')
 		)
 		body=(component bodyComponent
 			bodyRowComponent=bodyRowComponent
 			selectable=selectable
 			setRowWidth=(action (mut rowWidth))
 		)
-		sortProp=sortProp
 	)}}
 </table>

--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,8 @@
 {
   "name": "paper-data-table",
   "dependencies": {
-    "ember": "~2.8.0",
-    "ember-cli-shims": "~0.1.1",
-    "ember-cli-test-loader": "0.2.2",
+    "ember": "~2.10.0",
+    "ember-cli-shims": "0.1.3",
     "ember-qunit-notifications": "0.1.0",
     "hammer.js": "^2.0.8",
     "matchMedia": "0.2.0"

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,19 +2,24 @@
 module.exports = {
   scenarios: [
     {
-      name: 'default',
+      name: 'ember-lts-2.4',
       bower: {
-        dependencies: { }
+        dependencies: {
+          'ember': 'components/ember#lts-2-4'
+        },
+        resolutions: {
+          'ember': 'lts-2-4'
+        }
       }
     },
     {
-      name: 'ember-1.13',
+      name: 'ember-lts-2.8',
       bower: {
         dependencies: {
-          'ember': '~1.13.0'
+          'ember': 'components/ember#lts-2-8'
         },
         resolutions: {
-          'ember': '~1.13.0'
+          'ember': 'lts-2-8'
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -2,52 +2,55 @@
   "name": "paper-data-table",
   "version": "0.1.1",
   "description": "Material Data Table for ember-paper",
+  "keywords": [
+    "ember-addon",
+    "ember md table",
+    "ember material design table"
+  ],
+  "author": "",
+  "license": "MIT",
   "directories": {
     "doc": "doc",
     "test": "tests"
   },
+  "repository": "https://github.com/ibarrick/paper-data-table",
   "scripts": {
     "build": "ember build",
     "start": "ember server",
     "test": "ember try:each"
   },
-  "repository": "https://github.com/ibarrick/paper-data-table",
-  "engines": {
-    "node": ">= 0.10.0"
+  "dependencies": {
+    "ember-cli-babel": "^5.1.7",
+    "ember-cli-htmlbars": "^1.0.10"
   },
-  "author": "",
-  "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.4.2",
-    "ember-ajax": "^2.0.1",
-    "ember-cli": "2.6.2",
-    "ember-cli-app-version": "^1.0.0",
-    "ember-cli-dependency-checker": "^1.2.0",
+    "broccoli-asset-rev": "^2.4.5",
+    "ember-ajax": "^2.4.1",
+    "ember-cli": "2.10.0",
+    "ember-cli-app-version": "^2.0.0",
+    "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-github-pages": "0.1.0",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
-    "ember-cli-inject-live-reload": "^1.4.0",
-    "ember-cli-jshint": "^1.0.0",
-    "ember-cli-qunit": "^1.4.0",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.3",
+    "ember-cli-inject-live-reload": "^1.4.1",
+    "ember-cli-jshint": "^2.0.1",
+    "ember-cli-test-loader": "^1.1.0",
+    "ember-cli-qunit": "^3.0.1",
     "ember-cli-release": "^0.2.9",
     "ember-cli-sass": "5.6.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-composable-helpers": "0.27.0",
-    "ember-data": "^2.6.0",
+    "ember-data": "^2.10.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-paper": "1.0.0-alpha.11",
     "ember-resolver": "^2.0.3",
     "ember-truth-helpers": "1.2.0",
-    "loader.js": "^4.0.1"
+    "loader.js": "^4.0.10"
   },
-  "keywords": [
-    "ember-addon"
-  ],
-  "dependencies": {
-    "ember-cli-babel": "^5.1.6",
-    "ember-cli-htmlbars": "^1.0.3"
+  "engines": {
+    "node": ">= 0.12.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ember-cli-sass": "5.6.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-composable-helpers": "0.27.0",
+    "ember-composable-helpers": "^1.1.2",
     "ember-data": "^2.10.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -9,16 +9,16 @@
 
     {{content-for "head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 
     {{content-for "head-footer"}}
   </head>
   <body>
     {{content-for "body"}}
 
-    <script src="assets/vendor.js"></script>
-    <script src="assets/dummy.js"></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 import config from './config/environment';
 
 const Router = Ember.Router.extend({
-  location: config.locationType
+  location: config.locationType,
+  rootURL: config.rootURL
 });
 
 Router.map(function() {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -25,7 +25,10 @@
 					{{#each (sort-by table.sortDesc paginatedDesserts) as |dessert|}}
 						{{#body.row edit=true as |row|}}
 							{{#row.cell checkbox=true}}
-								{{#paper-checkbox value=dessert.checked onChange=(action (mut dessert.checked))}}{{/paper-checkbox}}
+								{{#paper-checkbox
+									value=dessert.checked
+									onChange=(action (mut dessert.checked))}}
+								{{/paper-checkbox}}
 							{{/row.cell}}
 							{{#row.cell}}{{dessert.name}}{{/row.cell}}
 							{{#row.cell numeric=true}}{{dessert.calories}}{{/row.cell}}
@@ -38,10 +41,15 @@
 							{{#row.cell edit=true as |cell|}}
 								{{#if cell.showEdit}}
 									{{#cell.edit-dialog onClose=cell.toggleEdit}}
-										{{paper-input value=dessert.comment onChange=(action (mut dessert.comment))}}
+										{{paper-input
+											value=dessert.comment
+											onChange=(action (mut dessert.comment))}}
 									{{/cell.edit-dialog}}
 								{{else}}
-									{{dessert.comment}}{{#paper-button iconButton=true onClick=row.toggleEdit}}{{paper-icon 'edit'}}{{/paper-button}}
+									{{dessert.comment}}
+									{{#paper-button iconButton=true onClick=row.toggleEdit}}
+										{{paper-icon 'edit'}}
+									{{/paper-button}}
 								{{/if}}
 							{{/row.cell}}
 						{{/body.row}}
@@ -59,5 +67,4 @@
 				onDecrementPage=(action 'decrementPage')}}
 		{{/card.content}}
 	{{/paper-card}}
-	{{!-- <div style="width: 100%; height: 100px"></div> --}}
 {{/paper-content}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -6,8 +6,8 @@
 {{#paper-content}}
 	{{#paper-card as |card|}}
 		{{#card.content}}
-			{{#paper-data-table selectable=true as |table|}}
-				{{#table.head sortProp="name" sortDir="asc" as |head|}}
+			{{#paper-data-table sortProp="name" sortDir="desc" selectable=true as |table|}}
+				{{#table.head as |head|}}
 					{{#head.column checkbox=true}}
 						{{#paper-checkbox disabled=true onChange=null}}{{/paper-checkbox}}
 					{{/head.column}}
@@ -22,7 +22,7 @@
 					{{#head.column}}Comment{{/head.column}}
 				{{/table.head}}
 				{{#table.body as |body|}}
-					{{#each (sort-by table.sortProp paginatedDesserts) as |dessert|}}
+					{{#each (sort-by table.sortDesc paginatedDesserts) as |dessert|}}
 						{{#body.row edit=true as |row|}}
 							{{#row.cell checkbox=true}}
 								{{#paper-checkbox value=dessert.checked onChange=(action (mut dessert.checked))}}{{/paper-checkbox}}

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -4,7 +4,7 @@ module.exports = function(environment) {
   var ENV = {
     modulePrefix: 'dummy',
     environment: environment,
-    baseURL: '/',
+    rootURL: '/',
     locationType: 'auto',
     EmberENV: {
       FEATURES: {
@@ -29,7 +29,7 @@ module.exports = function(environment) {
 
   if (environment === 'test') {
     // Testem prefers this...
-    ENV.baseURL = '/';
+    ENV.rootURL = '/';
     ENV.locationType = 'none';
 
     // keep test console output quieter
@@ -41,7 +41,7 @@ module.exports = function(environment) {
 
   if (environment === 'production') {
     ENV.locationType = 'hash';
-    ENV.baseURL = '/paper-data-table/';
+    ENV.rootURL = '/paper-data-table/';
 
   }
 

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -5,8 +5,8 @@ import config from '../../config/environment';
 export default function startApp(attrs) {
   let application;
 
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  // use defaults, but you can override
+  let attributes = Ember.assign({}, config.APP, attrs);
 
   Ember.run(() => {
     application = Application.create(attributes);

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,9 +10,9 @@
     {{content-for "head"}}
     {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
-    <link rel="stylesheet" href="assets/test-support.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
@@ -21,12 +21,11 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <script src="testem.js" integrity=""></script>
-    <script src="assets/vendor.js"></script>
-    <script src="assets/test-support.js"></script>
-    <script src="assets/dummy.js"></script>
-    <script src="assets/tests.js"></script>
-    <script src="assets/test-loader.js"></script>
+    <script src="/testem.js" integrity=""></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
+    <script src="{{rootURL}}assets/tests.js"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}


### PR DESCRIPTION
- Minor changes to the API
  - sortProp & sortDir are now being exposed on the paper-table instead of paper-table.header
  - sortDesc was added to support sort description of form "sortProp:sortDir" ("name:desc")