### PR TITLE
Ember 2.10.1 hash helper with action eagerly evaluates

### DIFF
--- a/addon/components/paper-data-table-row.js
+++ b/addon/components/paper-data-table-row.js
@@ -28,6 +28,9 @@ export default Component.extend({
 	},
 
 	actions: {
+		close() {
+			this.sendAction('onClose', this);
+		},
 		toggleEdit() {
 			this.toggleProperty('showEdit');
 		}


### PR DESCRIPTION
click action on paper-table-body-row was missing, however the template was using it