### PR TITLE
Fixes #15 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Port of https://github.com/daniel-nagy/md-data-table using ember-paper
 
   `ember install paper-data-table`
 
+  Add `@import 'paper-data-table';` to your `app.scss` file.
+
 ## Usage
 	From dummy app:
   ```hbs

--- a/app/styles/paper-data-table.scss
+++ b/app/styles/paper-data-table.scss
@@ -1,4 +1,3 @@
-@import 'ember-paper';
 @import 'md-variables';
 @import 'md-edit-dialog';
 @import 'md-table-pagination';


### PR DESCRIPTION
- Removes ember-paper style import
- Adds instructions on how to import paper-data-table styles

Fixes #15 