### PR TITLE
cap endOffset to total when available

### DIFF
--- a/addon/components/paper-data-table-pagination.js
+++ b/addon/components/paper-data-table-pagination.js
@@ -13,7 +13,9 @@ export default Component.extend({
 	startOffset: computed('page', 'limit', function() {
 		return Math.max((this.get('page') - 1) * this.get('limit') + 1, 1); // 1-based index
 	}),
-	endOffset: computed('startOffset', 'limit', function() {
-		return this.get('startOffset') + this.get('limit');
+	endOffset: computed('startOffset', 'limit', 'total', function() {
+	  let endOffset = this.get('startOffset') + this.get('limit');
+	  let total = this.get('total');
+		return total ? Math.min(endOffset, total) : endOffset;
 	})
 });

--- a/tests/integration/components/paper-data-table-pagination-test.js
+++ b/tests/integration/components/paper-data-table-pagination-test.js
@@ -1,0 +1,29 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('paper-data-table-pagination', 'Integration | Component | paper data table pagination', {
+  integration: true,
+  beforeEach() {
+    this.set('noop', function() {});
+  }
+});
+
+test('it renders startOffset - endOffset of total', function(assert) {
+  this.setProperties({
+    page: 1,
+    limit: 10,
+    total: null
+  });
+
+  this.render(hbs`{{paper-data-table-pagination onChangeLimit=noop page=page limit=limit total=total}}`);
+
+  assert.equal(this.$('.buttons > .label').text().trim(), '', 'Hidden if no total given');
+
+  this.set('total', 13);
+
+  assert.equal(this.$('.buttons > .label').text().trim(), '1 - 11 of 13');
+
+  this.set('page', 2);
+
+  assert.equal(this.$('.buttons > .label').text().trim(), '11 - 13 of 13', 'endOffset is capped at total');
+});


### PR DESCRIPTION
This PR fixes the label's display: `{startOffset} - {endOffset} of {total}` where `endOffset` could be bigger than `total`.