### PR TITLE
Adds possibility to reopen component paper-data-table-box

### DIFF
--- a/addon/components/paper-data-table-body.js
+++ b/addon/components/paper-data-table-body.js
@@ -1,11 +1,17 @@
 import Ember from 'ember';
 import layout from '../templates/components/paper-data-table-body';
 
-const { Component } = Ember;
+const {
+	Component,
+	String: { htmlSafe },
+} = Ember;
 
 export default Component.extend({
+	classNameBindings: ['md-body'],
+	attributeBindings: ['style'],
 	layout,
-  tagName: '',
-	cellspacing: "0",
-	cellpadding: "0",
+	tagName: 'tbody',
+	style: htmlSafe('position: relative;'),
+	cellspacing: '0',
+	cellpadding: '0',
 });

--- a/addon/templates/components/paper-data-table-body.hbs
+++ b/addon/templates/components/paper-data-table-body.hbs
@@ -1,6 +1,4 @@
-<tbody class="md-body" style="position: relative;">
-	{{yield (hash
-			row=(component bodyRowComponent selectable=selectable)
-		)
-	}}
-</tbody>
+{{yield (hash
+		row=(component bodyRowComponent selectable=selectable)
+	)
+}}


### PR DESCRIPTION
This pull request adds the functionality of adding attribute bindings on the paper-data-table-box.
This was not possible before these changes because the component had no tagName.
I need this for more precise selectors when using dragula.

Example: 

```javascript
// /app/components/paper-data-table-body.js
import PaperDataTableRow from 'paper-data-table/components/paper-data-table-body'

PaperDataTableRow.reopen({
    attributeBindings: [`data-title`],
})

export default PaperDataTableRow
```
```handlebars
{{!somewhere inside my handlebar template }}
{{#paper-data-table
    as |table|
}}
    {{#table.body
        data-title="wrapper-questions"
        as |body|
    }}
       ...
    {{/table.body}}
{{/paper-data-table}}
```


I also noticed
cellspacing and cellpadding are afaik unused properties