### PR TITLE
Add "colspan" attribute support to header columns

### DIFF
--- a/addon/components/paper-data-table-column.js
+++ b/addon/components/paper-data-table-column.js
@@ -12,7 +12,7 @@ export default Component.extend({
 	layout,
 	tagName: 'th',
 	classNameBindings: ['numeric:md-numeric','active:md-active','sortProp:md-sort'],
-	attributeBindings: ['style'],
+	attributeBindings: ['style','colspan'],
 	classNames: ['md-column'],
 	currentProp: null,
 	sortProp: null,


### PR DESCRIPTION
Currently it is only possible to add "colspan" to cells in body rows. This change adds support to add a colspan also to table header columns.

Example:
```hbs
{{#paper-data-table as |table|}}
    {{#table.head as |head|}}
        {{#head.column sortProp="date"}}Date{{/head.column}}
        {{#head.column sortProp="name"}}Name{{/head.column}}
        {{#head.column sortProp="value"}}Value{{/head.column}}
    {{/table.head}}

    {{#if isUpdatingTableData}}
        {{#table.head as |head|}}
            {{#head.column colspan="3"}}
                {{paper-progress-linear}}
            {{/head.column}}
        {{/table.head}}
    {{/if}}

    {{#table.body as |body|}}
         ....
    {{/table.body}}
{{/paper-data-table}}
```