### PR TITLE
Adds a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,114 @@
+# paper-data-table Changelog
+
+### 0.1.5 (August 11, 2017)
+
+- [#28](https://github.com/ibarrick/paper-data-table/pull/28) Add "colspan" attribute support to header columns
+- [2dbf42f](https://github.com/ibarrick/paper-data-table/commit/2dbf42f3b06e45d68fdf19a6620ede5006855e61) Yield itself in the paper-data-table-row component.
+- [#23](https://github.com/ibarrick/paper-data-table/pull/23) Replace classNameBindings with classNames in paper-data-table-body component
+- [#21](https://github.com/ibarrick/paper-data-table/pull/21) Adds possibility to reopen component paper-data-table-box
+- [#20](https://github.com/ibarrick/paper-data-table/pull/20) / [6c3aa00](https://github.com/ibarrick/paper-data-table/commit/6c3aa00956992a77ee305a4d696305b5c9a42a55) Adds travis badge to README
+- [#19](https://github.com/ibarrick/paper-data-table/pull/19) can pass custom sort action
+- [#17](https://github.com/ibarrick/paper-data-table/pull/17) cap endOffset to total when available
+
+### 0.1.4 (April 28, 2017)
+
+- [#16](https://github.com/ibarrick/paper-data-table/pull/16) Removes ember-paper style import (Fixes [#15](https://github.com/ibarrick/paper-data-table/issues/15))
+
+### 0.1.3 (February 17, 2017)
+
+- [#12](https://github.com/ibarrick/paper-data-table/pull/12) Ember 2.10.1 hash with action eagerly evaluates
+
+### 0.1.2 (December 6, 2016)
+
+- [#11](https://github.com/ibarrick/paper-data-table/pull/11) Don't default sortProp to name. Cleanup code inconsistency
+- [#10](https://github.com/ibarrick/paper-data-table/pull/10) Upgrade to ember 2.10 & fix backtrace/backflow errors & update README
+- [#9](https://github.com/ibarrick/paper-data-table/pull/9) fix(paper-data-table-dialog-inner) Don't modify a property inside the didInsertElement hook
+- [0eb22b1](https://github.com/ibarrick/paper-data-table/commit/0eb22b1c17d9a105449b205492406d361530443c) added fixed property
+
+### 0.1.1 (November 18, 2016)
+
+- [#7](https://github.com/ibarrick/paper-data-table/pull/7) remove unimplemented and sometimes failing test
+- [#6](https://github.com/ibarrick/paper-data-table/pull/6) can opt-out page selection by omitting the change action
+- [#5](https://github.com/ibarrick/paper-data-table/pull/5) add opt-in for start/end offset of the current page
+- [#4](https://github.com/ibarrick/paper-data-table/pull/4) add table's cell colspan binding
+
+### 0.1.0 (November 4, 2016)
+
+- [d2e2ad1](https://github.com/ibarrick/paper-data-table/commit/d2e2ad148aa2fb9a3f37bb2c18a84cf1e387d978) upgraded ember-paper and updated select components to new api
+- [#3](https://github.com/ibarrick/paper-data-table/pull/3) Expose table component parts
+
+### 0.0.18 (October 13, 2016)
+
+- [#2](https://github.com/ibarrick/paper-data-table/pull/2) Support default sort {property,direction}
+
+### 0.0.17 (September 30, 2016)
+
+- [5503b4d](https://github.com/ibarrick/paper-data-table/commit/5503b4de15a316c093bcd97eeb849e007fba96ed) removed stickyHeaders implementation because it was a useless hack
+
+### 0.0.16 (September 25, 2016)
+
+- [1c82393](https://github.com/ibarrick/paper-data-table/commit/1c823937e43043fa1b02a3f11f22bf192e28b93b) switched to htmlSafe
+
+### 0.0.15 (September 25, 2016)
+
+- [d8ef63c](https://github.com/ibarrick/paper-data-table/commit/d8ef63cac4c594deb7a5976a7b9eaab5567730af) allowed for setting the width of columns
+
+### 0.0.14 (September 25, 2016)
+
+- [00be974](https://github.com/ibarrick/paper-data-table/commit/00be9749eb9f706ab0a0e21ba575cac60c58cf5a) escaped css for rows
+
+### 0.0.13 (September 21, 2016)
+
+- [205864b](https://github.com/ibarrick/paper-data-table/commit/205864b444b1e13a8d2efa7fceced125e378c75d) style fix
+
+### 0.0.12 (September 21, 2016)
+
+- [8af4502](https://github.com/ibarrick/paper-data-table/commit/8af450270b2b6def5855feae7545277b5dca10a8) changed width of row
+
+### 0.0.10 (August 15, 2016)
+
+- [5a31e5a](https://github.com/ibarrick/paper-data-table/commit/5a31e5ab10232e6718de49f6ab64f9d55dfc96fb) focus issue
+
+### 0.0.9 (August 15, 2016)
+
+- [#1](https://github.com/ibarrick/paper-data-table/pull/1) Fixed stuff
+- [5b0c6c1](https://github.com/ibarrick/paper-data-table/commit/5b0c6c181017757e53623aaa5210273d95f21a70) jesus
+
+### 0.0.8 (August 15, 2016)
+
+- [0a19440](https://github.com/ibarrick/paper-data-table/commit/0a19440434c6214e28f453642eda068b6a236400) fix
+
+### 0.0.7 (August 15, 2016)
+
+- [6d0fb13](https://github.com/ibarrick/paper-data-table/commit/6d0fb13860a1fa6f036932c9924940035cf3b71e) fixed name I think
+
+### 0.0.6 (August 14, 2016)
+
+- [90baddd](https://github.com/ibarrick/paper-data-table/commit/90badddd388f8feb9b3a50e022967da88f27fe46) changed component name
+
+### 0.0.5 (July 22, 2016)
+
+- [2461b90](https://github.com/ibarrick/paper-data-table/commit/2461b9013cbe7688614bf9990553efcd4c1476d2) changed label class to be less conflicting
+
+### 0.0.4 (July 22, 2016)
+
+- [a282a65](https://github.com/ibarrick/paper-data-table/commit/a282a659cc0cdcf0eaffdcc27bf1fb98a31978b0) fixed the sort icon
+
+### 0.0.3 (July 21, 2016)
+
+- [81c6ae3](https://github.com/ibarrick/paper-data-table/commit/81c6ae35465ad1e09d334889620c1f98cd8532c6) added repo url
+
+### 0.0.2 (Jult 21, 2016)
+
+- [d84eacd](https://github.com/ibarrick/paper-data-table/commit/d84eacd3620ac20ccc53125046bde9ce94e00512) changed description
+
+### 0.0.1 (July 21, 2016)
+
+- [b2d72b5](https://github.com/ibarrick/paper-data-table/commit/b2d72b53b65c76bc8ef55b92e0ad889eef639e03) added demo url
+- [5f578ae](https://github.com/ibarrick/paper-data-table/commit/5f578aed92a95b5ca5b4814e04e46d95c6eb1108) added ember-cli-github-pages addon
+- [181675c](https://github.com/ibarrick/paper-data-table/commit/181675c88d9ffb2b125dfb42eb3e6ccf7148bdac) Update README.md
+- [3a15b1e](https://github.com/ibarrick/paper-data-table/commit/3a15b1ed2665ab7069bd30fb08b6f06f0f936806) Update README.md
+- [eee2ab8](https://github.com/ibarrick/paper-data-table/commit/eee2ab89764f33358956ef250b294334a05952ad) Update README.md
+- [386aaaa](https://github.com/ibarrick/paper-data-table/commit/386aaaab847635aba03daccddce5ce51d1fbfc52) readme updated
+- [976a80d](https://github.com/ibarrick/paper-data-table/commit/976a80d7450d13d900f6a10751680aef924dd374) initial commit wip
+


### PR DESCRIPTION
Adds a changelog to paper-data-table so tracking changes between releases is easier. Back dates all changes that happened with each release back to 0.0.1.