### PR TITLE
Show sort icon on the left for numeric columns

### DIFF
--- a/addon/templates/components/paper-data-table-column.hbs
+++ b/addon/templates/components/paper-data-table-column.hbs
@@ -1,8 +1,13 @@
-{{yield}}
+{{#unless numeric}}
+    {{yield}}
+{{/unless}}
 {{#if sortProp}}
 	{{#if active}}
 		{{paper-icon "arrow upward" class=(if (eq "asc" sortDir) "md-sort-icon md-asc" "md-sort-icon md-desc")}}
 	{{else}}
 		{{paper-icon "arrow downward" class="md-sort-icon md-desc" }}
 	{{/if}}
+{{/if}}
+{{#if numeric}}
+    {{yield}}
 {{/if}}


### PR DESCRIPTION
Currently the sort icon (arrow up/down) is always on the right of table header columns. When using numeric columns (numeric=true) the cell content is aligned on the right and the sort icon should then appear on the opposite side. This is defined in the guidelines and also looks much nicer.

See Guidelines Screenshot (Sorted column)
https://material.io/guidelines/components/data-tables.html#data-tables-interaction