### PR TITLE
Expose 'disabled' attribute on rows

### DIFF
--- a/addon/components/paper-data-table-row.js
+++ b/addon/components/paper-data-table-row.js
@@ -12,7 +12,7 @@ export default Component.extend({
 	tagName: 'tr',
 	classNames: ['md-row'],
 	showEdit: false,
-	attributeBindings: ['style'],
+	attributeBindings: ['style', 'disabled'],
 	style: computed('edit', 'onClick', function() {
 		if (this.get('onClick') || this.get('edit')) {
 			return htmlSafe('cursor: pointer;');


### PR DESCRIPTION
Expose the `disabled` attribute of table rows.

It will (among probably other things) disable the hover effect of the row.