### PR TITLE
override min-height/min-width defined by default on md-icon

### DIFF
--- a/app/styles/md-table.scss
+++ b/app/styles/md-table.scss
@@ -108,6 +108,8 @@ table.md-table {
       width: 16px;
       font-size: 16px !important;
       line-height: 16px !important;
+      min-height: 16px !important;
+      min-width: 16px !important;
 
       &.md-sort-icon {
         color: rgba(0, 0, 0, 26%);
@@ -226,7 +228,7 @@ table.md-table {
     color: rgba(0, 0, 0, 0.87);
     font-size: 13px;
     border-top: 1px rgba(0, 0, 0, 0.12) solid;
-    
+
     &.md-numeric md-select {
       justify-content: flex-end;
 


### PR DESCRIPTION
This PRs fixes the display of the sort icon.

Using the latest version of ember-paper (it may have existed before I don't know) I have a `min-height` and `min-width` on `md-icon` at `24px` by default.

Because of this the icon is in a 24x24 block instead of 16x16