### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^5.1.7",
+    "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^1.0.10"
   },
   "devDependencies": {


### PR DESCRIPTION
DEPRECATION: ember-cli-babel 5.x has been deprecated.